### PR TITLE
chore: add testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+dist: xenial
+node_js:
+  - lts/*
+
+install:
+  - npm install
+
+cache:
+  directories:
+    - node_modules
+
+script:
+  - npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,118 @@
+{
+  "name": "highlightjs-terraform",
+  "version": "1.0.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "highlight.js": {
+      "version": "9.15.6",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
+      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jasmine": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.3.1.tgz",
+      "integrity": "sha512-/vU3/H7U56XsxIXHwgEuWpCgQ0bRi2iiZeUpx7Nqo8n1TpoDHfZhkPIc7CO8I4pnMzYsi3XaSZEiy8cnTfujng==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.6",
+        "jasmine-core": "~3.3.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.3.0.tgz",
+      "integrity": "sha512-3/xSmG/d35hf80BEN66Y6g9Ca5l/Isdeg/j6zvbTYlTzeKinzmaTM4p9am5kYqOmE05D7s1t8FGjzdSnbUbceA==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "highlight.js syntax definition for Ethereum's terraform language",
   "main": "terraform.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jasmine"
   },
+  "files": [
+    "terraform.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/highlightjs/highlight-terraform.git"
@@ -21,5 +24,9 @@
   "bugs": {
     "url": "https://github.com/WinOpsDBA/highlightjs-terraform/issues"
   },
-  "homepage": "https://github.com/highlightjs/highlight-terraform#readme"
+  "homepage": "https://github.com/highlightjs/highlight-terraform#readme",
+  "devDependencies": {
+    "highlight.js": "^9.15.6",
+    "jasmine": "^3.3.1"
+  }
 }

--- a/spec/expected.txt
+++ b/spec/expected.txt
@@ -1,0 +1,29 @@
+<span class="hljs-comment"># Terraform (hcl)</span>
+
+<span class="hljs-keyword">variable</span> <span class="hljs-string">"string"</span> {
+  default = <span class="hljs-string">"string_test"</span> <span class="hljs-comment"># test inline comment</span>
+}
+
+<span class="hljs-keyword">resource</span> <span class="hljs-string">"azurerm_subnet"</span> <span class="hljs-string">"sn1"</span> {
+  count                = <span class="hljs-number">1</span>
+  number               = <span class="hljs-number">2.3</span>
+  boolean              = true
+  type                 = <span class="hljs-string">"<span class="hljs-variable">${var.string}</span>"</span>
+  name                 = <span class="hljs-string">"<span class="hljs-variable">${var.prefix}</span>-sn"</span>
+  resource_group_name  = <span class="hljs-string">"<span class="hljs-variable">${azurerm_resource_group.rg1.name}</span>"</span>
+  virtual_network      = <span class="hljs-string">"<span class="hljs-variable">${<span class="hljs-meta">cidrsubnet(<span class="hljs-string">"test"</span>,<span class="hljs-number">3</span>,<span class="hljs-meta">test()</span>)</span>}</span>"</span>
+  address_prefix       = <span class="hljs-string">"<span class="hljs-variable">${<span class="hljs-meta">cidrsubnet(<span class="hljs-string">"<span class="hljs-variable">${var.vnets[<span class="hljs-string">"<span class="hljs-variable">${var.location}</span>"</span>,<span class="hljs-string">"test1"</span>]}</span>"</span>,<span class="hljs-string">"<span class="hljs-variable">${var.network_size}</span>"</span>,<span class="hljs-number">3</span>,<span class="hljs-string">"test"</span>)</span>}</span>"</span>
+
+  tags = <span class="hljs-string">"<span class="hljs-variable">${<span class="hljs-meta">merge(local.tags, <span class="hljs-meta">map(<span class="hljs-string">"update"</span>,<span class="hljs-string">"<span class="hljs-variable">${<span class="hljs-meta">timestamp()</span>}</span>"</span>)</span>)</span>}</span>"</span>
+}
+
+<span class="hljs-keyword">output</span> <span class="hljs-string">"public_ip_address"</span> {
+  value = [<span class="hljs-string">"<span class="hljs-variable">${azurerm_public_ip.pip1.*.ip_address}</span>"</span>]
+}
+
+
+<span class="hljs-keyword">terraform</span> {
+  backend <span class="hljs-string">"azure"</span> {
+    storage_account_name = <span class="hljs-string">"azure"</span>
+  }
+}

--- a/spec/input.txt
+++ b/spec/input.txt
@@ -1,0 +1,29 @@
+# Terraform (hcl)
+
+variable "string" {
+  default = "string_test" # test inline comment
+}
+
+resource "azurerm_subnet" "sn1" {
+  count                = 1
+  number               = 2.3
+  boolean              = true
+  type                 = "${var.string}"
+  name                 = "${var.prefix}-sn"
+  resource_group_name  = "${azurerm_resource_group.rg1.name}"
+  virtual_network      = "${cidrsubnet("test",3,test())}"
+  address_prefix       = "${cidrsubnet("${var.vnets["${var.location}","test1"]}","${var.network_size}",3,"test")}"
+
+  tags = "${merge(local.tags, map("update","${timestamp()}"))}"
+}
+
+output "public_ip_address" {
+  value = ["${azurerm_public_ip.pip1.*.ip_address}"]
+}
+
+
+terraform {
+  backend "azure" {
+    storage_account_name = "azure"
+  }
+}

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true
+}

--- a/spec/terraform-spec.js
+++ b/spec/terraform-spec.js
@@ -1,0 +1,28 @@
+const hljs = require("highlight.js/lib/highlight");
+const { definer: terraform } = require("../terraform");
+const fs = require("fs");
+const path = require("path");
+hljs.registerLanguage("terraform", terraform);
+
+describe("respec-highlight bundle", () => {
+  it("highlights terraform", () => {
+    // Load the input file...
+    const input = fs.readFileSync(
+      path.resolve(__dirname, "./input.txt"),
+      "utf-8"
+    );
+
+    // Do the highlight...
+    const { value: result, language } = hljs.highlightAuto(input, [
+      "terraform",
+    ]);
+    expect(language).toBe("terraform");
+
+    // Check the output is what we expect...
+    const expected = fs.readFileSync(
+      path.resolve(__dirname, "./expected.txt"),
+      "utf-8"
+    );
+    expect(result).toBe(expected);
+  });
+});


### PR DESCRIPTION
To test, you can now just run `npm install`, and the `npm test`. 

TravisCI will pick up any test failures. 